### PR TITLE
set Power resource to later ver to handle openBMC

### DIFF
--- a/reddrum_frontend/Data/static/ServiceMetadata.xml
+++ b/reddrum_frontend/Data/static/ServiceMetadata.xml
@@ -105,7 +105,7 @@
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Power_v1.xml">
         <edmx:include Namespace="Power" />
-        <edmx:Include Namespace="Power.v1_2_0"/>
+        <edmx:Include Namespace="Power.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Redundancy_v1.xml">
         <edmx:include Namespace="Redundancy" />

--- a/reddrum_frontend/Data/templates/Power.json
+++ b/reddrum_frontend/Data/templates/Power.json
@@ -1,4 +1,4 @@
 {
     "@odata.context": "/redfish/v1/$metadata#Power.Power",
-    "@odata.type": "#Power.v1_2_0.Power"
+    "@odata.type": "#Power.v1_5_0.Power"
 }


### PR DESCRIPTION
we added physicalContext property to PowerControl in OpenBMC.
This was not supported until v1_5_0 of the Power resource so need to update the res ver