### PR TITLE
added oem schema support fixes and generating PSU,Fan,Voltages,Temper…

### DIFF
--- a/reddrum_frontend/Data/static/OdataServiceDocument.json
+++ b/reddrum_frontend/Data/static/OdataServiceDocument.json
@@ -45,6 +45,11 @@
             "name": "Sessions",
             "kind": "Singleton",
             "url": "/redfish/v1/SessionService/Sessions"
+        },
+        {
+            "name": "EventService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/EventService"
         }
     ]
 }

--- a/reddrum_frontend/Data/static/ServiceMetadata.xml
+++ b/reddrum_frontend/Data/static/ServiceMetadata.xml
@@ -13,187 +13,194 @@
       <edmx:Include Namespace="Chassis" />
       <edmx:Include Namespace="Chassis.v1_4_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/ChassisCollection_v1.xml">
-        <edmx:include Namespace="ChassisCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ChassisCollection_v1.xml">
+        <edmx:Include Namespace="ChassisCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
         <edmx:Include Namespace="ComputerSystem" />
         <edmx:Include Namespace="ComputerSystem.v1_3_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/ComputerSystemCollection_v1.xml">
-        <edmx:include Namespace="ComputerSystemCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystemCollection_v1.xml">
+        <edmx:Include Namespace="ComputerSystemCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterface_v1.xml">
-        <edmx:include Namespace="EthernetInterface" />
+        <edmx:Include Namespace="EthernetInterface" />
         <edmx:Include Namespace="EthernetInterface.v1_3_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/EthernetInterfaceCollection_v1.xml">
-        <edmx:include Namespace="EthernetInterfaceCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterfaceCollection_v1.xml">
+        <edmx:Include Namespace="EthernetInterfaceCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VLanNetworkInterface_v1.xml">
-        <edmx:include Namespace="VLanNetworkInterface" />
+        <edmx:Include Namespace="VLanNetworkInterface" />
         <edmx:Include Namespace="VLanNetworkInterface.v1_0_0"/>
     </edmx:Reference>  
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Event_v1.xml">
-        <edmx:include Namespace="Event" />
+        <edmx:Include Namespace="Event" />
         <edmx:Include Namespace="Event.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EventService_v1.xml">
-        <edmx:include Namespace="EventService" />
+        <edmx:Include Namespace="EventService" />
         <edmx:Include Namespace="EventService.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/IPAddresses_v1.xml">
-        <edmx:include Namespace="IPAddresses" />
+        <edmx:Include Namespace="IPAddresses" />
         <edmx:Include Namespace="IPAddresses.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/JsonSchemaFile_v1.xml">
-        <edmx:include Namespace="JsonSchemaFile" />
+        <edmx:Include Namespace="JsonSchemaFile" />
         <edmx:Include Namespace="JsonSchemaFile.v1_0_4"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/JsonSchemaFileCollection_v1.xml">
-        <edmx:include Namespace="JsonSchemaFileCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/JsonSchemaFileCollection_v1.xml">
+        <edmx:Include Namespace="JsonSchemaFileCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EventDestination_v1.xml">
-        <edmx:include Namespace="EventDestination" />
+        <edmx:Include Namespace="EventDestination" />
         <edmx:Include Namespace="EventDestination.v1_3_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/EventDestinationCollection_v1.xml">
-        <edmx:include Namespace="EventDestinationCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EventDestinationCollection_v1.xml">
+        <edmx:Include Namespace="EventDestinationCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogEntry_v1.xml">
-        <edmx:include Namespace="LogEntry" />
+        <edmx:Include Namespace="LogEntry" />
         <edmx:Include Namespace="LogEntry.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/LogEntryCollection_v1.xml">
-        <edmx:include Namespace="LogEntryCollection" />
-    </edmx:reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/Role_v1.xml">
-        <edmx:include Namespace="Role" />
-        <edmx:include Namespace="Role.v1_2_1" />
-    </edmx:reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/RoleCollection_v1.xml">
-        <edmx:include Namespace="RoleCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogEntryCollection_v1.xml">
+        <edmx:Include Namespace="LogEntryCollection" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Role_v1.xml">
+        <edmx:Include Namespace="Role" />
+        <edmx:Include Namespace="Role.v1_2_1" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RoleCollection_v1.xml">
+        <edmx:Include Namespace="RoleCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogService_v1.xml">
-        <edmx:include Namespace="LogService" />
+        <edmx:Include Namespace="LogService" />
         <edmx:Include Namespace="LogService.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/LogServiceCollection_v1.xml">
-        <edmx:include Namespace="LogServiceCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogServiceCollection_v1.xml">
+        <edmx:Include Namespace="LogServiceCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
-        <edmx:include Namespace="Manager"/>
+        <edmx:Include Namespace="Manager"/>
         <edmx:Include Namespace="Manager.v1_1_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/ManagerCollection_v1.xml">
-        <edmx:include Namespace="ManagerCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerCollection_v1.xml">
+        <edmx:Include Namespace="ManagerCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerAccount_v1.xml">
-        <edmx:include Namespace="ManagerAccount" />
+        <edmx:Include Namespace="ManagerAccount" />
         <edmx:Include Namespace="ManagerAccount.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/ManagerAccountCollection_v1.xml">
-        <edmx:include Namespace="ManagerAccountCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerAccountCollection_v1.xml">
+        <edmx:Include Namespace="ManagerAccountCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerNetworkProtocol_v1.xml">
-        <edmx:include Namespace="ManagerNetworkProtocol" />
+        <edmx:Include Namespace="ManagerNetworkProtocol" />
         <edmx:Include Namespace="ManagerNetworkProtocol.v1_2_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Message_v1.xml">
-        <edmx:include Namespace="Message" />
+        <edmx:Include Namespace="Message" />
         <edmx:Include Namespace="Message.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Power_v1.xml">
-        <edmx:include Namespace="Power" />
+        <edmx:Include Namespace="Power" />
         <edmx:Include Namespace="Power.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Redundancy_v1.xml">
-        <edmx:include Namespace="Redundancy" />
+        <edmx:Include Namespace="Redundancy" />
         <edmx:Include Namespace="Redundancy.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Processor_v1.xml">
-        <edmx:include Namespace="Processor" />
+        <edmx:Include Namespace="Processor" />
         <edmx:Include Namespace="Processor.v1_1_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/ProcessorCollection_v1.xml">
-        <edmx:include Namespace="ProcessorCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ProcessorCollection_v1.xml">
+        <edmx:Include Namespace="ProcessorCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Memory_v1.xml">
-        <edmx:include Namespace="Memory" />
+        <edmx:Include Namespace="Memory" />
         <edmx:Include Namespace="Memory.v1_3_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/MemoryCollection_v1.xml">
-        <edmx:include Namespace="MemoryCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MemoryCollection_v1.xml">
+        <edmx:Include Namespace="MemoryCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SerialInterface_v1.xml">
-        <edmx:include Namespace="SerialInterface" />
+        <edmx:Include Namespace="SerialInterface" />
         <edmx:Include Namespace="SerialInterface.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/SerialInterfaceCollection_v1.xml">
-        <edmx:include Namespace="SerialInterfaceCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SerialInterfaceCollection_v1.xml">
+        <edmx:Include Namespace="SerialInterfaceCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Session_v1.xml">
-        <edmx:include Namespace="Session" />
+        <edmx:Include Namespace="Session" />
         <edmx:Include Namespace="Session.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/SessionCollection_v1.xml">
-        <edmx:include Namespace="SessionCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SessionCollection_v1.xml">
+        <edmx:Include Namespace="SessionCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SessionService_v1.xml">
-        <edmx:include Namespace="SessionService" />
+        <edmx:Include Namespace="SessionService" />
         <edmx:Include Namespace="SessionService.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SimpleStorage_v1.xml">
-        <edmx:include Namespace="SimpleStorage" />
+        <edmx:Include Namespace="SimpleStorage" />
         <edmx:Include Namespace="SimpleStorage.v1_2_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/SimpleStorageCollection_v1.xml">
-        <edmx:include Namespace="SimpleStorageCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SimpleStorageCollection_v1.xml">
+        <edmx:Include Namespace="SimpleStorageCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Task_v1.xml">
-        <edmx:include Namespace="Task" />
+        <edmx:Include Namespace="Task" />
         <edmx:Include Namespace="Task.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/TaskCollection_v1.xml">
-        <edmx:include Namespace="TaskCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/TaskCollection_v1.xml">
+        <edmx:Include Namespace="TaskCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/TaskService_v1.xml">
-        <edmx:include Namespace="TaskService" />
+        <edmx:Include Namespace="TaskService" />
         <edmx:Include Namespace="TaskService.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Thermal_v1.xml">
-        <edmx:include Namespace="Thermal" />
+        <edmx:Include Namespace="Thermal" />
         <edmx:Include Namespace="Thermalv1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VirtualMedia_v1.xml">
-        <edmx:include Namespace="VirtualMedia" />
+        <edmx:Include Namespace="VirtualMedia" />
         <edmx:Include Namespace="VirtualMedia.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/VirtualMediaCollection_v1.xml">
-        <edmx:include Namespace="VirtualMediaCollection" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VirtualMediaCollection_v1.xml">
+        <edmx:Include Namespace="VirtualMediaCollection" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VLanNetworkInterface_v1.xml">
-        <edmx:include Namespace="VLanNetworkInterface" />
+        <edmx:Include Namespace="VLanNetworkInterface" />
         <edmx:Include Namespace="VLanNetworkInterface.v1_0_0"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/VLanNetworkInterfaceCollection_v1.xml">
-        <edmx:include Namespace="VLanNetworkInterface" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VLanNetworkInterfaceCollection_v1.xml">
+        <edmx:Include Namespace="VLanNetworkInterface" />
+    </edmx:Reference>
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
         <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
     </edmx:Reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/MessageRegistryFileCollection_v1.xml">
-        <edmx:include Namespace="MessageRegistryFileCollection" />
-    </edmx:reference>
-    <edmx:reference uri="http://redfish.dmtf.org/schemas/v1/MessageRegistryFile_v1.xml">
-        <edmx:include Namespace="MessageRegistryFile" />
-        <edmx:include Namespace="MessageRegistryFile.v1_0_0" />
-    </edmx:reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MessageRegistryFileCollection_v1.xml">
+        <edmx:Include Namespace="MessageRegistryFileCollection" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MessageRegistryFile_v1.xml">
+        <edmx:Include Namespace="MessageRegistryFile" />
+        <edmx:Include Namespace="MessageRegistryFile.v1_0_0" />
+    </edmx:Reference>
+    <edmx:Reference Uri="https://raw.githubusercontent.com/intel/intelRSD/master/CTS/sources/metadata/2_3/PSME/IntelRackScaleOem.xml">
+        <edmx:Include Namespace="Intel.Oem" />
+    </edmx:Reference>
+    <edmx:Reference Uri="https://raw.githubusercontent.com/RedDrum-Redfish-Project/RedDrum-Frontend/v1.x.x/schemas/DellG5MC_v1.xml">
+        <edmx:Include Namespace="DellG5MC" />
+        <edmx:Include Namespace="DellG5MC.v1_0_0" />
+    </edmx:Reference>
 
     <edmx:DataServices>
  
       <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Service">
-          <EntityContainer Name="Service" Extends="ServiceRoot.v1_0_2.ServiceContainer"/>
+          <EntityContainer Name="Service" Extends="ServiceRoot.v1_1_3.ServiceContainer"/>
       </Schema>
 
   </edmx:DataServices>

--- a/reddrum_frontend/chassis.py
+++ b/reddrum_frontend/chassis.py
@@ -311,12 +311,12 @@ class RfChassisResource():
 
         if "ActionsOemSledReseat" in self.chassisDb[chassisid]:
             if self.chassisDb[chassisid]["ActionsOemSledReseat"] is True:
-                resetAction = { "target": basePath + chassisid + "/Actions/Chassis.Reseat" }
+                resetAction = { "target": basePath + chassisid + "/Actions/Oem/DellG5MC.SledReseat" }
                 if "Actions" not in responseData2:
                     responseData2["Actions"]={}
                 if "Oem" not in responseData2["Actions"]:
                     responseData2["Actions"]["Oem"]={}
-                responseData2["Actions"]["Oem"]["#Dell.G5SledReseat"]= resetAction
+                responseData2["Actions"]["Oem"]["#DellG5MC.SledReseat"]= resetAction
 
         # build Dell OEM Section (Sleds only)
         if "Oem" in self.chassisDb[chassisid]:
@@ -329,6 +329,7 @@ class RfChassisResource():
                 if prop in self.chassisDb[chassisid]["Oem"]:
                     # since these sub-props are nonVolatile, read them from the database
                     oemData[prop] = self.chassisDb[chassisid]["Oem"][prop]
+            oemData["@odata.type"] = "#DellG5MC.v1_0_0.Chassis"
             if "Oem" not in responseData2:
                 responseData2["Oem"]={}
             responseData2["Oem"]["Dell_G5MC"] = oemData
@@ -618,13 +619,15 @@ class RfChassisResource():
         if chassisid in self.tempSensorsDb:
             # set the base static properties that were assigned when the resource was created
             temperatureArray=list()
+            index=0
             if "Id" not in self.tempSensorsDb[chassisid]:
                 self.tempSensorsDb[chassisid]={ "Id": {} }
             for sensorId in self.tempSensorsDb[chassisid]["Id"]:   # sensors "0", "1", ...
                 sensorData={}
+                sensorIndex=str(index)
 
                 # add the required Id and MemberId properties
-                sensorData["@odata.id"] = basePath + chassisid + "/Thermal#/Temperatures/" + sensorId
+                sensorData["@odata.id"] = basePath + chassisid + "/Thermal#/Temperatures/" + sensorIndex
                 sensorData["MemberId"]  = sensorId
 
                 # add the static properties
@@ -672,6 +675,9 @@ class RfChassisResource():
                 # add the Temperatures entry array to the Temperatures array
                 temperatureArray.append(sensorData)
 
+                # next member index
+                index = index + 1
+
             # Add the new member to the Temperatures array
             if "Temperatures" not in responseData2:
                 responseData2["Temperatures"]={}
@@ -693,15 +699,17 @@ class RfChassisResource():
         # add Fan Array properties
         if chassisid in self.fansDb:
             fanArray=list()
+            index = 0
             if "Id" not in self.fansDb[chassisid]:
                 self.fansDb[chassisid]={ "Id": {} }
            
             # set the base static properties that were assigned when the resource was created
             for fanId in self.fansDb[chassisid]["Id"]:   # fan "0", "1", ...
                 sensorData={}
+                sensorIndex=str(index)
 
                 # add the required Id and MemberId properties
-                sensorData["@odata.id"] = basePath + chassisid + "/Thermal#/Fans/" + fanId
+                sensorData["@odata.id"] = basePath + chassisid + "/Thermal#/Fans/" + sensorIndex
                 sensorData["MemberId"]  = fanId
 
                 # add the static properties
@@ -755,6 +763,7 @@ class RfChassisResource():
                     redundancySetMembers.append(redundancySetMember)
 
                 fanArray.append(sensorData)
+                index = index + 1
 
             # Add the new member to the Fan array
             if "Fans" not in responseData2:
@@ -773,12 +782,15 @@ class RfChassisResource():
                 fansRedundancyStatusSubProperties=["State", "Health"]
 
                 redundancyArray=list()
+                index = 0
+
                 # set the base static properties for this redundancy group
                 for redundancyGroup in self.fansDb[chassisid]["RedundancyGroup"]:
                     sensorData={}
+                    sensorIndex = str(index)
 
                     # add the required Id and MemberId properties
-                    sensorData["@odata.id"] = basePath + chassisid + "/Thermal#/Redundancy/" + redundancyGroup
+                    sensorData["@odata.id"] = basePath + chassisid + "/Thermal#/Redundancy/" + sensorIndex
                     sensorData["MemberId"]  = redundancyGroup
  
                     # add the standard redundancyProperty Properties that this service uses
@@ -798,7 +810,8 @@ class RfChassisResource():
                     for prop in statusProps:
                         sensorData[prop] = statusProps[prop]
 
-                redundancyArray.append(sensorData)
+                    redundancyArray.append(sensorData)
+                    index = index + 1
 
                 # Add the new member to the Redundancy array
                 if "Redundancy" not in responseData2:
@@ -894,13 +907,15 @@ class RfChassisResource():
         if chassisid in self.voltageSensorsDb:
             # set the base static properties that were assigned when the resource was created
             voltagesArray=list()
+            index = 0
             if "Id" not in self.voltageSensorsDb[chassisid]:
                 self.voltageSensorsDb[chassisid]={ "Id": {} }
             for sensorId in self.voltageSensorsDb[chassisid]["Id"]:   # sensors "0", "1", ...
                 sensorData={}
+                sensorIndex = str(index)
 
                 # add the required Id and MemberId properties
-                sensorData["@odata.id"] = basePath + chassisid + "/Power#/Voltages/" + sensorId
+                sensorData["@odata.id"] = basePath + chassisid + "/Power#/Voltages/" + sensorIndex
                 sensorData["MemberId"]  = sensorId
 
                 # add the static properties
@@ -950,6 +965,7 @@ class RfChassisResource():
 
                 # add the Voltages entry array to the voltage array
                 voltagesArray.append(sensorData)
+                index = index + 1
 
             # Add the new member to the Voltages array
             if "Voltages" not in responseData2:
@@ -976,13 +992,15 @@ class RfChassisResource():
         # add the powerControl members to the array
         if chassisid in self.powerControlDb:
             powerControlArray=list()
+            index = 0
             if "Id" not in self.powerControlDb[chassisid]:
                 self.powerControlDb[chassisid]={ "Id": {} }
             for powerControlId  in self.powerControlDb[chassisid]["Id"]:
                 sensorData={}
+                sensorIndex = str(index)
 
                 # add the required Id and MemberId properties
-                sensorData["@odata.id"] = basePath + chassisid + "/Power#/PowerControl/" + powerControlId
+                sensorData["@odata.id"] = basePath + chassisid + "/Power#/PowerControl/" + sensorIndex
                 sensorData["MemberId"]  = powerControlId
  
                 # add the standard static Properties that this service uses
@@ -1032,6 +1050,7 @@ class RfChassisResource():
                         sensorData["RelatedItem"] = relatedItemMembers
 
                 powerControlArray.append(sensorData)
+                index = index + 1
 
             # Add the new member to the Redundancy array
             if "PowerControl" not in responseData2:
@@ -1059,15 +1078,17 @@ class RfChassisResource():
         # add PowerSupply Array properties
         if chassisid in self.powerSuppliesDb:
             psusArray=list()
+            index = 0
             if "Id" not in self.powerSuppliesDb[chassisid]:
                 self.powerSuppliesDb[chassisid]={ "Id": {} }
 
             # set the base static properties that were assigned when the resource was created
             for psuId in self.powerSuppliesDb[chassisid]["Id"]:   # powerSupply "0", "1", ...
                 sensorData={}
+                sensorIndex = str(index)
 
                 # add the required Id and MemberId properties
-                sensorData["@odata.id"] = basePath + chassisid + "/Power#/PowerSupplies/" + psuId
+                sensorData["@odata.id"] = basePath + chassisid + "/Power#/PowerSupplies/" + sensorIndex
                 sensorData["MemberId"]  = psuId
 
                 # add the static properties
@@ -1116,6 +1137,7 @@ class RfChassisResource():
                     redundancySetMembers.append(redundancySetMember)
 
                 psusArray.append(sensorData)
+                index = index + 1
 
             # Add the new member to the PowerSupplies (psus) array
             if "PowerSupplies" not in responseData2:
@@ -1134,12 +1156,14 @@ class RfChassisResource():
                 psusRedundancyStatusSubProperties=["State", "Health"]
 
                 redundancyArray=list()
+                index = 0
                 # set the base static properties for this redundancy group
                 for redundancyGroup in self.powerSuppliesDb[chassisid]["RedundancyGroup"]:
                     sensorData={}
+                    sensorIndex = str(index)
 
                     # add the required Id and MemberId properties
-                    sensorData["@odata.id"] = basePath + chassisid + "/Power#/Redundancy/" + redundancyGroup
+                    sensorData["@odata.id"] = basePath + chassisid + "/Power#/Redundancy/" + sensorIndex
                     sensorData["MemberId"]  = redundancyGroup
  
                     # add the standard redundancyProperty Properties that this service uses
@@ -1159,7 +1183,8 @@ class RfChassisResource():
                     for prop in statusProps:
                         sensorData[prop] = statusProps[prop]
 
-                redundancyArray.append(sensorData)
+                    redundancyArray.append(sensorData)
+                    index = index + 1
 
                 # Add the new member to the Redundancy array
                 if "Redundancy" not in responseData2:

--- a/reddrum_frontend/managers.py
+++ b/reddrum_frontend/managers.py
@@ -334,7 +334,7 @@ class RfManagersResource():
                 if prop in self.managersDb[managerid]["OemDellG5MCMgrInfo"]:
                     # since these sub-properties are nonVolatile, read them from the database
                     oemData[prop]=self.managersDb[managerid]["OemDellG5MCMgrInfo"][prop]
-
+            oemData["@odata.type"]="#DellG5MC.v1_0_0.Manager"
             if "Oem" not in responseData2:
                 responseData2["Oem"]={}
             responseData2["Oem"]["Dell_G5MC"] = oemData

--- a/reddrum_frontend/redDrumStartURIs.py
+++ b/reddrum_frontend/redDrumStartURIs.py
@@ -678,7 +678,7 @@ def rdStart_RedDrum_Flask_app(rdr):
     # Chassis Oem Reseat
     # POST /redfish/v1/Chassis/<chassisid>/Actions/Chassis.Reseat -- Reseat chassis
     #    -auth,  post to chassis  at reseat target URI
-    @app.route("/redfish/v1/Chassis/<chassisid>/Actions/Chassis.Reseat", methods=['POST'])
+    @app.route("/redfish/v1/Chassis/<chassisid>/Actions/Oem/DellG5MC.SledReseat", methods=['POST'])
     @rfcheckHeaders(rfr)
     @auth.rfAuthRequired(rdr, privilege=[["ConfigureComponents"]]) 
     def rfChassisOemReseat(chassisid):

--- a/reddrum_frontend/systems.py
+++ b/reddrum_frontend/systems.py
@@ -328,6 +328,7 @@ class RfSystemsResource():
             if oemNetloc in self.systemsDb[systemid]:
                 oemData[oemNetloc]= self.systemsDb[systemid][oemNetloc]
 
+            oemData["@odata.type"] = "#DellG5MC.v1_0_0.ComputerSystem"
             if "Oem" not in responseData2:
                 responseData2["Oem"]={}
             responseData2["Oem"]["Dell_G5MC"] = oemData

--- a/schemas/DellG5MC.json
+++ b/schemas/DellG5MC.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2018 Dell Inc. ",
+    "definitions": {},
+    "owningEntity": "Dell_G5MC",
+    "title": "#DellG5MC"
+}

--- a/schemas/DellG5MC.v1_0_0.json
+++ b/schemas/DellG5MC.v1_0_0.json
@@ -1,0 +1,219 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2018 Dell Inc. ",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#DellG5MC.SledReseat": {
+                    "$ref": "#/definitions/SledReseat"
+                }
+            },
+            "type": "object"
+        },
+        "Chassis": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ParentSled": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SledType": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SysIdForJbodSled": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ComputerSystem": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BmcIp": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "BmcMac": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "BmcVersion": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MgtNetworkEnableStatus": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MgtNetworkIP": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MgtNetworkLinkStatus": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MgtNetworkMAC": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MgtNetworkNetloc": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Manager": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LastUpdateStatus": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "OpenLockupTableVersion": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SafeBoot": {
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "SledReseat": {
+            "additionalProperties": false,
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "Dell_G5MC",
+    "title": "#DellG5MC.v1_0_0"
+}

--- a/schemas/DellG5MC_v1.xml
+++ b/schemas/DellG5MC_v1.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# DellG5MC OEM Extensions used on G5MC and Dss9000 RackManager                         -->
+<!--#                                                                                      -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager.xml">
+    <edmx:Include Namespace="Manager.v1_3_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem.v1_1_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis.v1_4_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="DellG5MC">
+      <Annotation Term="Redfish.OwningEntity" String="Dell_G5MC"/>
+
+      <Action Name="SledReseat" IsBound="true">
+        <Parameter Name="Chassis" Type="Chassis.v1_4_0.oemActions"/>
+      </Action>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="DellG5MC.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="Dell_G5MC"/>
+
+      <!--G5MC-specific extensions to Chassis-->
+      <ComplexType Name="Chassis" BaseType="Resource.OemObject">
+        <Property Name="SysIdForJbodSled" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="SledType" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="ParentSled" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+      </ComplexType>
+
+      <!--G5MC-specific extensions to Manager-->
+      <ComplexType Name="Manager" BaseType="Resource.OemObject">
+        <Annotation Term="Odata.AdditionalProperties" Bool="false"/>
+        <Property Name="OpenLockupTableVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="SafeBoot" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="LastUpdateStatus" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+      </ComplexType>
+
+      <!--G5MC-specific extensions to Computer System-->
+      <ComplexType Name="ComputerSystem" BaseType="Resource.OemObject">
+        <Annotation Term="Odata.AdditionalProperties" Bool="false"/>
+        <Property Name="BmcMac" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="BmcIp" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="BmcVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="MgtNetworkNetloc" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="MgtNetworkIP" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="MgtNetworkEnableStatus" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="MgtNetworkMAC" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="MgtNetworkLinkStatus" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+
+</edmx:Edmx>
+


### PR DESCRIPTION
added oem schema support fixes and generating PSU,Fan,Voltages,Tempttures,PowerCntl array member odata.ids so that they are correct independent of the ids used:
1) now calculating the indexes in Thermal and Power for the resource arrays of Fans, Temperatures, Voltages, PowerControl, PowerSupplies, Redundancy.   eg @odata.id= ....#Fans/<index>
Previously we were using the id for the index and requiring the backend to set proper Ids which is not good since Id "could" be a string
2) added RackScale Oem schema to Metadata
3) added DellG5MC_v1 oem schema to metadata
4) fixed mispelling in metadata file re Uri, References, Include
5) created a DellG5MC_v1.xml oem metadata file  that is in github at RedDrum-Frontend/schemas/
6) now inserting an @odata.id in the oem tagged Dell_G5MC data for Managers, Chassis, and ComputerSystems
7) corrected the oem action chassis Reseat  to conform with Redfish recommendation.
    This changes the URI of the sledReleat Action from previous versions.
    No problem is the user is correctly getting the uri with hypermedia read of target property